### PR TITLE
fix: add tagger to help with dev deployments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1253,11 +1253,6 @@
         "which": "^1.2.9"
       }
     },
-    "cursor": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/cursor/-/cursor-0.1.5.tgz",
-      "integrity": "sha1-6neMKwnTPC5WT9khRwdnUEg+uyw="
-    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -3196,17 +3191,14 @@
       "optional": true
     },
     "mazzaroth-js": {
-      "version": "0.1.0-dev.c0b204f089",
-      "resolved": "https://registry.npmjs.org/mazzaroth-js/-/mazzaroth-js-0.1.0-dev.c0b204f089.tgz",
-      "integrity": "sha512-WLK7zrzeiD01DF2bbc9myLD75ioBP4dfB0cP0/M+raO8Z4WPjsa0ralprKW4a5Ph5zCLo0ho6zGCijqwr87i+A==",
+      "version": "0.1.0-dev.5a77968a4d",
+      "resolved": "https://registry.npmjs.org/mazzaroth-js/-/mazzaroth-js-0.1.0-dev.5a77968a4d.tgz",
+      "integrity": "sha512-JEvd+FilgQEmR0dVq8alZql4unJN9lNE+qtZWcsQeKpmSrA3eg6B0HguLbYw/+Po1E7PfF6Hyz0YrKk2+A9Nrg==",
       "requires": {
         "axios": "^0.18.0",
-        "commander": "^2.19.0",
-        "cursor": "^0.1.5",
         "debug": "^4.1.1",
         "elliptic": "^6.4.1",
         "mazzaroth-xdr": "^0.1.0-dev.246226679",
-        "nearley": "^2.16.0",
         "xdr-js-serialize": "^0.1.0-dev.44cdb73ec2"
       }
     },
@@ -3601,6 +3593,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "package-tagger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/package-tagger/-/package-tagger-0.1.1.tgz",
+      "integrity": "sha512-uUg5I58HiXuW6mbScLeRHz5b2QfdnO2BA9XqrsAlKBbvo629nKg/VXC3ihia2fUVbOVuOiMPffJo6DzdvGH54A==",
       "dev": true
     },
     "parent-module": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "eslint-plugin-mocha": "^5.3.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-standard": "^4.0.0"
+    "eslint-plugin-standard": "^4.0.0",
+    "package-tagger": "^0.1.1"
   },
   "dependencies": {
     "commander": "^2.19.0",


### PR DESCRIPTION
The deployment step for mazzaroth-cli is failing for the develop branch because we didn't have the package-tagger dependency, which it uses to append "-dev.commit" to the package.json version.